### PR TITLE
Registration endpoint refactor + 2 new endpoints

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -14,17 +14,17 @@ func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
 	router.Handle("/", alice.New().ThenFunc(GetAllCurrentRegistrations)).Methods("GET")
-	router.Handle("/{id}/", alice.New().ThenFunc(GetAllRegistrations)).Methods("GET")
-
+	
 	router.Handle("/attendee/", alice.New().ThenFunc(GetCurrentUserRegistration)).Methods("GET")
 	router.Handle("/attendee/", alice.New().ThenFunc(CreateCurrentUserRegistration)).Methods("POST")
 	router.Handle("/attendee/", alice.New().ThenFunc(UpdateCurrentUserRegistration)).Methods("PUT")
 	router.Handle("/filter/", alice.New().ThenFunc(GetFilteredUserRegistrations)).Methods("GET")
-
+	
 	router.Handle("/mentor/", alice.New().ThenFunc(GetCurrentMentorRegistration)).Methods("GET")
 	router.Handle("/mentor/", alice.New().ThenFunc(CreateCurrentMentorRegistration)).Methods("POST")
 	router.Handle("/mentor/", alice.New().ThenFunc(UpdateCurrentMentorRegistration)).Methods("PUT")
-
+	
+	router.Handle("/{id}/", alice.New().ThenFunc(GetAllRegistrations)).Methods("GET")
 	router.Handle("/attendee/{id}/", alice.New().ThenFunc(GetUserRegistration)).Methods("GET")
 	router.Handle("/mentor/{id}", alice.New().ThenFunc(GetMentorRegistration)).Methods("GET")
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -13,16 +13,16 @@ import (
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/", alice.New().ThenFunc(GetCurrentUserRegistration)).Methods("GET")
-	router.Handle("/", alice.New().ThenFunc(CreateCurrentUserRegistration)).Methods("POST")
-	router.Handle("/", alice.New().ThenFunc(UpdateCurrentUserRegistration)).Methods("PUT")
+	router.Handle("/attendee/", alice.New().ThenFunc(GetCurrentUserRegistration)).Methods("GET")
+	router.Handle("/attendee/", alice.New().ThenFunc(CreateCurrentUserRegistration)).Methods("POST")
+	router.Handle("/attendee/", alice.New().ThenFunc(UpdateCurrentUserRegistration)).Methods("PUT")
 	router.Handle("/filter/", alice.New().ThenFunc(GetFilteredUserRegistrations)).Methods("GET")
 
 	router.Handle("/mentor/", alice.New().ThenFunc(GetCurrentMentorRegistration)).Methods("GET")
 	router.Handle("/mentor/", alice.New().ThenFunc(CreateCurrentMentorRegistration)).Methods("POST")
 	router.Handle("/mentor/", alice.New().ThenFunc(UpdateCurrentMentorRegistration)).Methods("PUT")
 
-	router.Handle("/{id}/", alice.New().ThenFunc(GetUserRegistration)).Methods("GET")
+	router.Handle("/attendee/{id}/", alice.New().ThenFunc(GetUserRegistration)).Methods("GET")
 	router.Handle("/mentor/{id}", alice.New().ThenFunc(GetMentorRegistration)).Methods("GET")
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -13,6 +13,9 @@ import (
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
+	router.Handle("/", alice.New().ThenFunc(GetAllCurrentRegistrations)).Methods("GET")
+	router.Handle("/{id}/", alice.New().ThenFunc(GetAllRegistrations)).Methods("GET")
+
 	router.Handle("/attendee/", alice.New().ThenFunc(GetCurrentUserRegistration)).Methods("GET")
 	router.Handle("/attendee/", alice.New().ThenFunc(CreateCurrentUserRegistration)).Methods("POST")
 	router.Handle("/attendee/", alice.New().ThenFunc(UpdateCurrentUserRegistration)).Methods("PUT")
@@ -24,6 +27,44 @@ func SetupController(route *mux.Route) {
 
 	router.Handle("/attendee/{id}/", alice.New().ThenFunc(GetUserRegistration)).Methods("GET")
 	router.Handle("/mentor/{id}", alice.New().ThenFunc(GetMentorRegistration)).Methods("GET")
+}
+
+/*
+	Endpoint to get all registrations (attendee, mentor) for the current user.
+	If registrations could not be found for either attendee or mentor, that field is set to nil/null.
+*/
+func GetAllCurrentRegistrations(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	user_registration, _ := service.GetUserRegistration(id)
+
+	mentor_registration, _ := service.GetMentorRegistration(id)
+
+	var all_registration = models.AllRegistration{
+		Attendee: user_registration,
+		Mentor:   mentor_registration,
+	}
+
+	json.NewEncoder(w).Encode(&all_registration)
+}
+
+/*
+	Endpoint to get all registrations (attendee, mentor) for the specified user.
+	If registrations could not be found for either attendee or mentor, that field is set to nil.
+*/
+func GetAllRegistrations(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	user_registration, _ := service.GetUserRegistration(id)
+
+	mentor_registration, _ := service.GetMentorRegistration(id)
+
+	var all_registration = models.AllRegistration{
+		Attendee: user_registration,
+		Mentor:   mentor_registration,
+	}
+
+	json.NewEncoder(w).Encode(&all_registration)
 }
 
 /*

--- a/docs/Registration.md
+++ b/docs/Registration.md
@@ -1,7 +1,7 @@
 Registration
 ============
 
-GET /registration/USERID/
+GET /registration/attendee/USERID/
 -------------------------
 
 Returns the user registration stored for the user with the `id` `USERID`.
@@ -52,7 +52,7 @@ Response format:
 }
 ```
 
-GET /registration/
+GET /registration/attendee/
 ------------------
 
 Returns the user registration stored for the user with the `id` stored in the given JWT in the Authorization header.
@@ -103,7 +103,7 @@ Response format:
 }
 ```
 
-POST /registration/
+POST /registration/attendee/
 -------------------
 
 Creates a registration for the user with the `id` in the JWT token provided in the Authorization header.
@@ -199,7 +199,7 @@ Response format:
 }
 ```
 
-PUT /registration/
+PUT /registration/attendee/
 ------------------
 
 Updated the registration for the user with the `id` in the JWT token provided in the Authorization header.

--- a/docs/Registration.md
+++ b/docs/Registration.md
@@ -1,6 +1,132 @@
 Registration
 ============
 
+GET /registration/
+-------------------------
+
+Returns all the registrations stored for the current user. If registrations are not found for either Attendee or Mentor,
+that field is set to null.
+
+Response format:
+```
+{
+	"attendee": {
+		"id": "github0000001"
+		"firstName": "John",
+		"lastName": "Smith",
+		"email": "john@gmail.com",
+		"shirtSize": "M",
+		"diet": "NONE",
+		"age": 19,
+		"graduationYear": 2019,
+		"transportation": "NONE",
+		"school": "University of Illinois at Urbana-Champaign",
+		"major": "Computer Science",
+		"gender": "MALE",
+		"professionalInterest": "INTERNSHIP",
+		"github": "JSmith",
+		"linkedin": "john-smith",
+		"interests": "Software",
+		"isNovice": false,
+		"isPrivate": false,
+		"phoneNumber": "555-555-5555",
+		"longforms": [
+			{
+				"response": "This is a longform."
+			}
+		],
+		"extraInfos": [
+			{
+				"response": "This is an extra info."
+			}
+		],
+		"osContributors": [
+			{
+				"name": "Tom",
+				"contactInfo": "tom@gmail.com"
+			}
+		],
+		"collaborators": [
+			{
+				"github": "collabgithub"
+			}
+		]
+	},
+	"mentor": {
+		"id": "github0000001"
+		"firstName": "John",
+		"lastName": "Smith",
+		"email": "john@gmail.com",
+		"shirtSize": "M",
+		"github": "JSmith",
+		"linkedin": "john-smith"
+	} 
+}
+```
+
+GET /registration/USERID/
+-------------------------
+
+Returns all registrations stored for the user with the `id` `USERID`.
+If registrations are not found for either Attendee or Mentor, that field is set to null.
+
+Response format:
+```
+{
+	"attendee": {
+		"id": "github0000001"
+		"firstName": "John",
+		"lastName": "Smith",
+		"email": "john@gmail.com",
+		"shirtSize": "M",
+		"diet": "NONE",
+		"age": 19,
+		"graduationYear": 2019,
+		"transportation": "NONE",
+		"school": "University of Illinois at Urbana-Champaign",
+		"major": "Computer Science",
+		"gender": "MALE",
+		"professionalInterest": "INTERNSHIP",
+		"github": "JSmith",
+		"linkedin": "john-smith",
+		"interests": "Software",
+		"isNovice": false,
+		"isPrivate": false,
+		"phoneNumber": "555-555-5555",
+		"longforms": [
+			{
+				"response": "This is a longform."
+			}
+		],
+		"extraInfos": [
+			{
+				"response": "This is an extra info."
+			}
+		],
+		"osContributors": [
+			{
+				"name": "Tom",
+				"contactInfo": "tom@gmail.com"
+			}
+		],
+		"collaborators": [
+			{
+				"github": "collabgithub"
+			}
+		]
+	},
+	"mentor": {
+		"id": "github0000001"
+		"firstName": "John",
+		"lastName": "Smith",
+		"email": "john@gmail.com",
+		"shirtSize": "M",
+		"github": "JSmith",
+		"linkedin": "john-smith"
+	}
+}
+```
+
 GET /registration/attendee/USERID/
 -------------------------
 

--- a/models/all_registration.go
+++ b/models/all_registration.go
@@ -1,0 +1,6 @@
+package models
+
+type AllRegistration struct {
+	Attendee *UserRegistration   `json:"attendee"`
+	Mentor   *MentorRegistration `json:"mentor"`
+}

--- a/models/mentor_registration.go
+++ b/models/mentor_registration.go
@@ -1,11 +1,11 @@
 package models
 
 type MentorRegistration struct {
-    ID          string  `json:"id"          validate:"required"`
-    FirstName   string  `json:"firstName"   validate:"required"`
-    LastName    string  `json:"lastName"    validate:"required"`
-    Email       string  `json:"email"       validate:"required,email"`
-    ShirtSize   string  `json:"shirtSize"   validate:"required,oneof=S M L XL"`
-    GitHub      string  `json:"github"      validate:"required"`
-    Linkedin    string  `json:"linkedin"    validate:"required"`
+	ID        string `json:"id"          validate:"required"`
+	FirstName string `json:"firstName"   validate:"required"`
+	LastName  string `json:"lastName"    validate:"required"`
+	Email     string `json:"email"       validate:"required,email"`
+	ShirtSize string `json:"shirtSize"   validate:"required,oneof=S M L XL"`
+	GitHub    string `json:"github"      validate:"required"`
+	Linkedin  string `json:"linkedin"    validate:"required"`
 }

--- a/tests/registration_test.go
+++ b/tests/registration_test.go
@@ -352,11 +352,11 @@ var base_user_registration models.UserRegistration = models.UserRegistration{
 }
 
 var base_mentor_registration models.MentorRegistration = models.MentorRegistration{
-	ID:                   "testid",
-	FirstName:            "first",
-	LastName:             "last",
-	Email:                "test@gmail.com",
-	ShirtSize:            "M",
-	GitHub:               "githubusername",
-	Linkedin:             "linkedinusername",
+	ID:        "testid",
+	FirstName: "first",
+	LastName:  "last",
+	Email:     "test@gmail.com",
+	ShirtSize: "M",
+	GitHub:    "githubusername",
+	Linkedin:  "linkedinusername",
 }


### PR DESCRIPTION
Addresses #35.

- [x] Convert GET, PUT, POST /registration/ and GET /registration/{id}/ to GET, PUT, POST /registration/attendee/ and GET /registration/attendee/{id}/

- [x] Add a new GET /registration/{id}/ which returns all the registrations (mentor, attendee) for a given user's id

- [x] Add a new GET /registration/ which returns all the registrations (mentor, attendee) for the current user